### PR TITLE
Persist previously selected segment after reloading a file

### DIFF
--- a/platform/Windows/c64d/c64d.vcxproj
+++ b/platform/Windows/c64d/c64d.vcxproj
@@ -1182,7 +1182,6 @@
     <ClCompile Include="..\..\..\src\Plugins\GoatTracker\gt2\gsong.c" />
     <ClCompile Include="..\..\..\src\Plugins\GoatTracker\gt2\gsound.c" />
     <ClCompile Include="..\..\..\src\Plugins\GoatTracker\gt2\gtable.c" />
-    <ClCompile Include="..\..\..\src\Plugins\ShowPic\C64DebuggerPluginShowPic.cpp" />
     <ClCompile Include="..\..\..\src\RetroDebuggerAppInit.cpp" />
     <ClCompile Include="..\..\..\src\Screens\CViewAbout.cpp" />
     <ClCompile Include="..\..\..\src\Screens\CViewBreakpointsOLD.cpp" />
@@ -2515,7 +2514,6 @@
     <ClInclude Include="..\..\..\src\Plugins\GoatTracker\gt2\gsong.h" />
     <ClInclude Include="..\..\..\src\Plugins\GoatTracker\gt2\gsound.h" />
     <ClInclude Include="..\..\..\src\Plugins\GoatTracker\gt2\gtable.h" />
-    <ClInclude Include="..\..\..\src\Plugins\ShowPic\C64DebuggerPluginShowPic.h" />
     <ClInclude Include="..\..\..\src\RetroDebuggerAppInit.h" />
     <ClInclude Include="..\..\..\src\Screens\CViewAbout.h" />
     <ClInclude Include="..\..\..\src\Screens\CViewBreakpointsOLD.h" />

--- a/platform/Windows/c64d/c64d.vcxproj.filters
+++ b/platform/Windows/c64d/c64d.vcxproj.filters
@@ -225,9 +225,6 @@
     <Filter Include="Source Files\src\Plugins\DNDK">
       <UniqueIdentifier>{e4d4b877-3cfa-4be8-9c25-6a126d9c5052}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Source Files\src\Plugins\ShowPic">
-      <UniqueIdentifier>{7c3e62b9-daae-4208-a5ee-25db0dd086c6}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Source Files\src\DebugInterface\C64">
       <UniqueIdentifier>{0690dda0-2e4f-4e5d-a2d5-5373b635933e}</UniqueIdentifier>
     </Filter>
@@ -3643,9 +3640,6 @@
     </ClCompile>
     <ClCompile Include="..\..\..\src\DebugInterface\Symbols\CDebugSymbolsDataWatch.cpp">
       <Filter>Source Files\src\DebugInterface\Symbols</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\Plugins\ShowPic\C64DebuggerPluginShowPic.cpp">
-      <Filter>Source Files\src\Plugins\ShowPic</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\DebugInterface\C64\CDebugInterfaceC64.cpp">
       <Filter>Source Files\src\DebugInterface\C64</Filter>
@@ -7674,9 +7668,6 @@
     </ClInclude>
     <ClInclude Include="..\..\..\src\DebugInterface\Symbols\CDebugSymbolsDataWatch.h">
       <Filter>Source Files\src\DebugInterface\Symbols</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\src\Plugins\ShowPic\C64DebuggerPluginShowPic.h">
-      <Filter>Source Files\src\Plugins\ShowPic</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\DebugInterface\C64\CDebugInterfaceC64.h">
       <Filter>Source Files\src\DebugInterface\C64</Filter>

--- a/src/DebugInterface/Symbols/CDebugAsmSource.cpp
+++ b/src/DebugInterface/Symbols/CDebugAsmSource.cpp
@@ -676,8 +676,8 @@ void CDebugAsmSource::ParseXML(CByteBuffer *byteBuffer, CDebugInterface *debugIn
 		}
 	}
 	
-	// activate first segment
-	symbols->ActivateSegment(symbols->segments[0]);
+	// activate first or selected segment
+	symbols->ActivateSelectedSegment();
 	
 	LOGM("CDebugAsmSource::ParseXML: symbols loaded");
 }

--- a/src/DebugInterface/Symbols/CDebugSymbols.h
+++ b/src/DebugInterface/Symbols/CDebugSymbols.h
@@ -37,9 +37,11 @@ public:
 	
 	std::vector<CDebugSymbolsSegment *> segments;
 	CDebugSymbolsSegment *currentSegment;
+	CSlrString *previousSegmentName;
 	int currentSegmentNum;
 	CDebugSymbolsSegment *FindSegment(CSlrString *segmentName);
 	
+	void ActivateSelectedSegment();
 	void ActivateSegment(CDebugSymbolsSegment *segment);
 	void DeactivateSegment();
 	

--- a/src/Views/CViewDisassembly.cpp
+++ b/src/Views/CViewDisassembly.cpp
@@ -923,6 +923,11 @@ int CViewDisassembly::RenderDisassemblyLine(float px, float py, int addr, uint8 
 	char buf4[16];
 	char bufHexCodes[16];
 	int length;
+
+	if (symbols->currentSegment == NULL)
+	{
+		return 0;
+	}
 	
 	CDebugBreakpointsAddr *breakpoints = symbols->currentSegment->breakpointsPC;
 	


### PR DESCRIPTION
Persist the previous segment name and check if it exists when reloading a file. If it exists, it will use that as the selected segment rather than defaulting to the first segment in the array. This is helpful when working on cartridge games and you've had to do reload after making a change.

Additional changes.
 - Removed C64DebuggerPluginShowPic.h and C64DebuggerPluginShowPic.cpp from the .vcxproj as these files are missing
 - CViewDisassembly.cpp: Add a null check for the currentSegment as this has sometimes caused a crash when debugging