### PR TITLE
Changed CMakeList.txt to include the right file for CViewC64KeyMap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1361,7 +1361,7 @@ add_executable(retrodebugger
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Views/C64/CViewC64StateCPU.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Views/JukeboxPlaylist/CViewJukeboxPlaylist.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Views/JukeboxPlaylist/CJukeboxPlaylist.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/Screens/CViewC64KeyMap.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/Views/C64/CViewC64KeyMap.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Screens/CViewKeyboardShortcuts.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Screens/VicEditor/C64DisplayListCodeGenerator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Screens/VicEditor/CVicEditorTool.cpp"


### PR DESCRIPTION
Fix for issue #45.
Changed CMakeLists.txt to include the CViewC64KeyMap.cpp under src/Views/C64