### PR TITLE
CMake: fix wrong braces around CMAKE_C_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ add_definitions(
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
-set(CMAKE_C_FLAGS "$(CMAKE_C_FLAGS) -fpermissive")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpermissive")
 
 find_package(PkgConfig REQUIRED)
 find_package(SDL2 REQUIRED)


### PR DESCRIPTION

Explanation:

The typo goes unnoticed with the default cmake-generator (Unix Makefiles)
But if you switch to another cmake-generator - eg Ninja (using option "-G Ninja") the following error appears when attempting build:

```
# cmake --build _build.dir -j 1;
ninja: error: build.ninja:165: bad $-escape (literal $ must be written as $$)
  FLAGS = $(CMAKE_C_FLAGS) -fpermissive -O2 -g -DNDEBUG   -pthread
          ^ near here
```

This PR fixes this error/problem by changing the erroneous ()'s into {}'s

