### PR TITLE
Update CDebugSymbolsSegment.cpp

### DIFF
--- a/src/DebugInterface/Symbols/CDebugSymbolsSegment.cpp
+++ b/src/DebugInterface/Symbols/CDebugSymbolsSegment.cpp
@@ -574,7 +574,7 @@ void CDebugSymbolsSegment::AddWatch(int address, int numberOfValues, CSlrString 
 			representation = WATCH_REPRESENTATION_BIN;
 		}
 		else if (strRepresentation->CompareWith("bin32")
-				 || strRepresentation->CompareWith("bin32"))
+				 || strRepresentation->CompareWith("b32"))
 		{
 			representation = WATCH_REPRESENTATION_BIN;
 		}


### PR DESCRIPTION
found a typo leading to a bug (not recognizing "b32" modifier) when reading debug watches.