### PR TITLE
Fix potential vulnerable clone function

### DIFF
--- a/src/Emulators/vice/monitor/mon_lex.c
+++ b/src/Emulators/vice/monitor/mon_lex.c
@@ -1576,6 +1576,7 @@ static void unescape(char *s) {
     while (*s) {
         if (*s == '\\') {
             s++;
+            if (*s == 0) { goto send; }
             switch (*s) {
                 case '\\': *d = '\\'; break; /* backslash */
                 case 'n': *d = '\n'; break; /* lf */


### PR DESCRIPTION
### Summary

Our tool detected a potential out-of-bound read vulnerability in `unescape()` in `src/Emulators/vice/monitor/mon_lex.c` which was cloned from https://github.com/GNUAspell/aspell/commit/80fa26c74279fced8d778351cff19d1d8f44fe4e but did not receive the security patch. The original issue was reported and fixed under [CVE-2019-17544](https://nvd.nist.gov/vuln/detail/CVE-2019-17544).

### Proposed Fix

Apply the same patch to eliminate the vulnerability.

### Reference

https://nvd.nist.gov/vuln/detail/CVE-2019-17544
https://github.com/GNUAspell/aspell/commit/80fa26c74279fced8d778351cff19d1d8f44fe4e