### PR TITLE
WebSockets server: fix crash when enabled from the menu, 16 kB payload cap, duplicate endpoint descriptors

### DIFF
--- a/src/Remote/WebSockets/CDebuggerServerWebSockets.cpp
+++ b/src/Remote/WebSockets/CDebuggerServerWebSockets.cpp
@@ -32,6 +32,7 @@ CDebuggerServerWebSockets::CDebuggerServerWebSockets(int port)
 {
 	app = NULL;
 	serverStarted = false;
+	startRequested = false;
 	numConnectedClients = 0;
 }
 
@@ -42,12 +43,18 @@ void CDebuggerServerWebSockets::SetPort(int port)
 
 void CDebuggerServerWebSockets::Start()
 {
-	if (serverStarted)
+	// serverStarted and isRunning are both set by the server thread once it is up, so
+	// two Start() calls in a row (the menu handler used to do exactly that) both see
+	// them false and the second SYS_StartThread hits SYS_FatalExit("thread is already
+	// running") — the process dies instantly, with no dialog and no log entry. This
+	// flag is set here, synchronously, so the second call is refused instead.
+	if (startRequested || serverStarted)
 	{
 		LOGError("CDebuggerServerWebSockets: server already started");
 		return;
 	}
 
+	startRequested = true;
 	SYS_StartThread(this);
 }
 
@@ -58,13 +65,16 @@ void CDebuggerServerWebSockets::Stop()
 	if (!serverStarted)
 	{
 		LOGError("CDebuggerServerWebSockets: server is not running");
+		// a start that never reached the listening state must not block the next one
+		startRequested = false;
 		return;
 	}
-	
+
 	if (!listenSocket)
 	{
 		LOGError("CDebuggerServerWebSockets: listenSocket is NULL");
 		serverStarted = false;
+		startRequested = false;
 		return;
 	}
 	
@@ -279,6 +289,12 @@ void CDebuggerServerWebSockets::ThreadRun(void *passData)
 	// for uWS topic management. They don't go through RunEndpointFunction.
 
 	app->ws<SocketData>("/stream", {
+		// uWS defaults to 16 kB, and anything above it is dropped by closing the socket
+		// without an error or a close frame — so a client sending a whole PRG or disk
+		// image in one writeBlock just loses the connection with no way to tell why.
+		// 4 MB covers every realistic payload here (64 kB RAM, D64, D81, CRT) with room
+		// to spare. Field order must match the declaration order in uWS::WebSocketBehavior.
+		.maxPayloadLength = 4 * 1024 * 1024,
 		.idleTimeout = 0,              // Disable uWS idle timeout — bridge has its own 30s socket timeout
 		.sendPingsAutomatically = false, // No auto-pings when idle timeout is disabled
 		.open = [this](auto* ws)
@@ -437,6 +453,7 @@ void CDebuggerServerWebSockets::ThreadRun(void *passData)
 	delete app;
 	app = NULL;
 	serverStarted = false;
+	startRequested = false;
 }
 
 void CDebuggerServerWebSockets::AddEndpointFunction(const string& functionName, function<vector<char>*(const string, const json, u8 *, int)> func)
@@ -447,6 +464,20 @@ void CDebuggerServerWebSockets::AddEndpointFunction(const string& functionName, 
 void CDebuggerServerWebSockets::AddEndpointFunction(const EndpointDescriptor &desc, EndpointHandlerV1 handler)
 {
 	endpointFunctions[desc.fn] = handler;
+
+	// The handler map is keyed by fn, so a re-registration replaces it; the descriptor
+	// vector has no such key and would keep a stale twin. That happens for real: a
+	// duplicated registration, and every Stop()+Start() cycle, which re-runs the whole
+	// registration and would otherwise grow the descriptor list without bound.
+	for (size_t i = 0; i < endpointDescriptors.size(); i++)
+	{
+		if (endpointDescriptors[i].fn == desc.fn)
+		{
+			endpointDescriptors[i] = desc;
+			return;
+		}
+	}
+
 	endpointDescriptors.push_back(desc);
 }
 

--- a/src/Remote/WebSockets/CDebuggerServerWebSockets.h
+++ b/src/Remote/WebSockets/CDebuggerServerWebSockets.h
@@ -17,6 +17,9 @@ public:
 	virtual void Stop();
 	
 	bool serverStarted;
+	// set synchronously by Start(), unlike serverStarted/isRunning which are only set
+	// once the server thread is already up — see the comment in Start()
+	bool startRequested;
 	int numConnectedClients;
 
 	virtual void AddEndpointFunction(const std::string& endpointName, std::function<std::vector<char> *(const std::string, const nlohmann::json, u8 *, int)> func);

--- a/src/Views/CMainMenuBar.cpp
+++ b/src/Views/CMainMenuBar.cpp
@@ -3044,21 +3044,32 @@ void CMainMenuBar::RenderImGui()
 				ImGui::Separator();
 				if (ImGui::MenuItem("WebSockets debugger server", "", &c64SettingsRunDebuggerServerWebSockets))
 				{
-					if (viewC64->debuggerServer == NULL)
+					if (c64SettingsRunDebuggerServerWebSockets)
 					{
-						viewC64->DebuggerServerWebSocketsStart();
-					}
-					if (viewC64->debuggerServer != NULL)
-					{
-						if (c64SettingsRunDebuggerServerWebSockets)
+						// DebuggerServerWebSocketsStart() creates AND starts the server, so
+						// calling Start() afterwards used to start the same thread twice and
+						// kill the process in SYS_StartThread. Start() only when the server
+						// object already exists.
+						if (viewC64->debuggerServer == NULL)
+						{
+							viewC64->DebuggerServerWebSocketsStart();
+						}
+						else
 						{
 							viewC64->debuggerServer->Start();
+						}
+
+						if (viewC64->debuggerServer != NULL)
+						{
 							char *buf = SYS_GetCharBuf();
 							sprintf(buf, "WebSockets server started on port %d.", c64SettingsRunDebuggerServerWebSocketsPort);
 							guiMain->ShowNotification("Information", buf);
 							SYS_ReleaseCharBuf(buf);
 						}
-						else
+					}
+					else
+					{
+						if (viewC64->debuggerServer != NULL)
 						{
 							viewC64->debuggerServer->Stop();
 							if (viewC64->debuggerServer->AreClientsConnected())


### PR DESCRIPTION
Three independent defects in the WebSockets debugger server, found while driving the debugger
from scripts. They are grouped because they all live in `CDebuggerServerWebSockets`.

## 1. Enabling the server from the menu kills the process

Clicking Settings -> Emulation -> "WebSockets debugger server" made the application vanish
instantly: no dialog, no message box, nothing in the log. Starting the server from
`settings.hjson` instead was always healthy, which pointed at the enable-at-runtime path.

`CViewC64::DebuggerServerWebSocketsStart()` (`CViewC64.cpp:4480-4497`) both **creates and
starts** the server. The menu handler then called `Start()` again on the object it had just
created, and a second `SYS_StartThread()` on a running `CSlrThread` ends in
`SYS_FatalExit("thread %d is already running")` -- an immediate exit. With `GLOBAL_DEBUG_OFF`
the `LOGError` above it compiles to nothing, so the log stays empty.

The existing `if (serverStarted)` guard cannot catch this: `serverStarted` is set inside
`ThreadRun()` and `CSlrThread::isRunning` is set by the newly spawned thread, so two calls in
a row both observe them as false. This adds `startRequested`, set synchronously inside
`Start()`, and makes the menu handler start the server only once.

## 2. Payloads of 16 kB or more silently kill the connection

`uWS::WebSocketBehavior` defaults `maxPayloadLength` to `16 * 1024` (`App.h:251`) and the
server never overrides it. Above that, uWS force-closes the socket **without an error and
without a close frame** -- the client just sees the connection drop. Measured: the largest
payload that gets through is 16300 bytes.

In practice that means a PRG or a disk image cannot be sent in one `writeBlock`, and there is
no feedback explaining why. Raised to 4 MB, which covers 64 kB of RAM, D64, D81 and CRT with
room to spare. The field must sit before `.idleTimeout` to satisfy C++20 designated
initializer ordering.

## 3. `endpointDescriptors` had no dedupe

`AddEndpointFunction(desc, handler)` writes the handler into a map keyed by `fn` (so a second
registration replaces it) but unconditionally `push_back`s the descriptor. The two containers
then disagree. Today this is visible as `server/capabilities` reporting `endpointCount` 78 for
c64 while only 77 endpoints are reachable -- `c64/drive1541/ram/clear` is registered twice
(`CDebuggerServerApiVice.cpp:454` and `:735`).

It also grows without bound: registration runs inside `ThreadRun()`, so every `Stop()` +
`Start()` cycle appends a fresh copy of every descriptor. The fix replaces an existing entry
with the same `fn` in place, keeping first-registration order and last-wins metadata,
consistent with how the handler map already behaves.

## Verification

Debian 13, same binary before/after:

| | before | after |
|---|---|---|
| 32 kB `ram/writeBlock` | connection lost, no error | HTTP 200, read-back matches byte for byte |
| `capabilities` vs `endpoints` (c64) | 78 declared / 77 real | 78 / 78 |

The crash was verified by hand after the fix: toggling the menu item off and on repeatedly,
plus restarting the application with the setting both `false` and `true` and toggling again --
no crash in any of those. Before the fix, enabling it from the menu killed the process every
time. Note when reproducing: the run has to start with `RunDebuggerServerWebSockets: false`,
otherwise the first click *disables* the server and never reaches the double-start path.
