### PR TITLE
Fix Linux build on master: add missing CDebuggerApi::GetWarpSpeed() referenced by #114

### DIFF
--- a/src/DebugInterface/CDebuggerApi.cpp
+++ b/src/DebugInterface/CDebuggerApi.cpp
@@ -539,6 +539,11 @@ void CDebuggerApi::SetWarpSpeed(bool isWarpSpeed)
 	debugInterface->SetSettingIsWarpSpeed(isWarpSpeed);
 }
 
+bool CDebuggerApi::GetWarpSpeed()
+{
+	return debugInterface->GetSettingIsWarpSpeed();
+}
+
 bool CDebuggerApi::KeyboardDown(u32 mtKeyCode)
 {
 	return debugInterface->KeyboardDown(mtKeyCode);

--- a/src/DebugInterface/CDebuggerApi.h
+++ b/src/DebugInterface/CDebuggerApi.h
@@ -111,6 +111,7 @@ public:
 	
 	//
 	virtual void SetWarpSpeed(bool isWarpSpeed);
+	virtual bool GetWarpSpeed();
 
 	// input
 	virtual bool KeyboardDown(u32 mtKeyCode);


### PR DESCRIPTION
Sorry -- this one is on me. When I split the original branch into three PRs, the split went by **file**, and `CDebuggerServerApi.cpp` carried hunks belonging to two topics: the `warp/get` endpoint landed in #114, while the `CDebuggerApi::GetWarpSpeed()` method it calls stayed in the still-open #116. With #114 and #115 merged and #116 paused, master fails on Linux:

```
src/Remote/CDebuggerServerApi.cpp:112:47: error: 'class CDebuggerApi' has no
member named 'GetWarpSpeed'; did you mean 'SetWarpSpeed'?
```

This PR adds exactly that method -- declaration plus a trivial forward to the existing `CDebugInterface::GetSettingIsWarpSpeed()` -- and nothing else. Verified: `master` + this patch builds clean on Debian 13 / GCC 14. Once merged, #116 will be rebased so the hunk does not appear twice.

**The macOS and Windows failures on the same CI runs are a different story** and predate nothing in the merged code:

- macOS dies in MTEngineSDL's `Libtool libMTEngineSDL.a` step -- Apple libtool from the Xcode 26.6 runner image prints its Usage banner, i.e. it no longer accepts one of the passed flags. Neither merged PR touches MTEngineSDL or the Xcode project.
- Windows dies in bundled SDL headers: `SDL_endian.h(40,1): error: definition of builtin function '_m_prefetch'` -- a known bundled-SDL2-vs-newer-MSVC clash, again in files the PRs do not touch.

The last green CI run on master was in June; the runner images have moved since, so these two would have failed on any push. I am digging into both and will follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)