### PR TITLE
Fix Windows CI: pin windows-2022 -- new image's clang-cl 22 rejects bundled SDL's _m_prefetch

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -9,7 +9,16 @@ on:
 
 jobs:
   build-windows:
-    runs-on: windows-latest
+    # Pinned: windows-latest now resolves to the Windows Server 2025 / VS 2026
+    # image, whose bundled clang-cl is >= 21 and defines _m_prefetch as a builtin.
+    # MTEngineSDL's bundled SDL 2.28.5 header (SDL_endian.h) redefines it under
+    # plain "#ifdef __clang__", which is now a hard error:
+    #   SDL_endian.h(40,1): error : definition of builtin function '_m_prefetch'
+    # windows-2022 ships VS 2022 (clang-cl 19.x, servicing-only, so it will stay
+    # < 21). The proper fix is upstream SDL's one-line guard change in the
+    # bundled header (MTEngineSDL repo); once that lands, this pin can go back
+    # to windows-latest.
+    runs-on: windows-2022
 
     steps:
       - name: Checkout RetroDebugger


### PR DESCRIPTION
The Windows job dies compiling MTEngineSDL (single error in the whole log):

```
SDL_endian.h(40,1): error : definition of builtin function '_m_prefetch'
```

**Nothing changed in either repo.** The `windows-2025-vs2026` runner image was updated between the last green run (June, clang-cl **20.1.8**) and now (clang-cl **22.1.3**). Since clang 21, `_m_prefetch` is a compiler builtin, and the SDL 2.28.5 header bundled in MTEngineSDL redefines it under a plain `#ifdef __clang__` (an old Clang-11-vs-winnt.h workaround). There were no CI runs between June and the #114/#115 merges, so the failure surfaced on the first push after the image update -- the merged PRs touch neither MTEngineSDL nor the workflow. (Both June and August runs used the same VS-2026 image family and the same MSVC 14.51 -- the only variable that moved is the bundled clang: 20.1.8 green, 22.1.3 red.)

**This PR:** pin `windows-2022` (VS 2022, clang-cl 19.x, servicing-only -- its clang stays below 21). One-line change, buys a working CI immediately.

**The proper fix** is a one-line guard change in MTEngineSDL's bundled header, mirroring what upstream SDL2 did on their branch (not yet in any SDL2 release -- 2.32.10 still has the plain `#ifdef`):

```diff
-#ifdef __clang__
+#if defined(__clang__) && !_SDL_HAS_BUILTIN(_m_prefetch)
```

(with the underscore -- `_SDL_HAS_BUILTIN` is the SDL2 spelling; upstream's first attempt used the SDL3 name `SDL_HAS_BUILTIN` and did not compile, they fixed it in a follow-up commit. Safe for older toolchains: clang 11-20 report no such builtin, so the workaround stays active for them.) Since AGENTS.md says MTEngineSDL changes need your sign-off: say the word and I'll send that PR there too, then this pin can go back to `windows-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)