### PR TITLE
API: make keyboard key events actually reach the emulated C64; add run/frames for deterministic replay

### DIFF
--- a/src/DebugInterface/CDebugInterface.cpp
+++ b/src/DebugInterface/CDebugInterface.cpp
@@ -619,6 +619,14 @@ void CDebugInterface::StepOverSubroutine()
 
 bool CDebugInterface::RunEmulationForOneFrame()
 {
+	return RunEmulationForFrames(1);
+}
+
+bool CDebugInterface::RunEmulationForFrames(uint32 numFrames)
+{
+	if (numFrames < 1)
+		return false;
+
 	if (!isRunning)
 		return false;
 
@@ -642,7 +650,7 @@ bool CDebugInterface::RunEmulationForOneFrame()
 
 		frameStepRequestGeneration++;
 		requestGeneration = frameStepRequestGeneration;
-		frameStepTargetFrameNumber = GetEmulationFrameNumber() + 1;
+		frameStepTargetFrameNumber = GetEmulationFrameNumber() + numFrames;
 		frameStepPending = true;
 		frameStepTargetVSyncReached = false;
 	}
@@ -650,7 +658,9 @@ bool CDebugInterface::RunEmulationForOneFrame()
 	SetDebugMode(DEBUGGER_MODE_RUNNING);
 
 	bool frameCompleted = false;
-	for (int tries = 0; tries < 100; tries++)
+	// wait budget scales with the requested frame count (50 ms per try; a realtime PAL frame is 20 ms)
+	const int maxTries = 100 + (int)numFrames * 2;
+	for (int tries = 0; tries < maxTries; tries++)
 	{
 		std::unique_lock<std::mutex> lock(frameStepMutex);
 		frameCompleted = frameStepCV.wait_for(lock, std::chrono::milliseconds(50), [this, requestGeneration]() {

--- a/src/DebugInterface/CDebugInterface.h
+++ b/src/DebugInterface/CDebugInterface.h
@@ -221,6 +221,7 @@ public:
 	virtual void StepOneCycle();
 	virtual void StepOverSubroutine();
 	virtual bool RunEmulationForOneFrame();
+	virtual bool RunEmulationForFrames(uint32 numFrames);
 	
 	virtual void RunContinueEmulation();
 

--- a/src/Emulators/vice/ViceInterface/CDebugInterfaceVice.cpp
+++ b/src/Emulators/vice/ViceInterface/CDebugInterfaceVice.cpp
@@ -1317,11 +1317,20 @@ bool CDebugInterfaceVice::KeyboardDown(uint32 mtKeyCode)
 			return false;
 	}
 
+	C64KeyMap *keyMap = C64KeyMapGetDefault();
+	if (keyMap == NULL)
+		return false;
+
+	C64KeyCode *key = keyMap->FindKeyCode(mtKeyCode);
+	if (key == NULL)
+		return false;
+
 	CDebugInterfaceViceTaskKeyboardEvent *task =
-		new CDebugInterfaceViceTaskKeyboardEvent(this, DEBUGGER_EVENT_BUTTON_DOWN, mtKeyCode);
+		new CDebugInterfaceViceTaskKeyboardEvent(this, DEBUGGER_EVENT_BUTTON_DOWN, mtKeyCode,
+												 key->matrixRow, key->matrixCol, key->shift);
 	AddCpuDebugInterruptTask(task);
 	c64d_vice_input_tasks_flag = 1;
-	return false;
+	return true;
 }
 
 bool CDebugInterfaceVice::KeyboardUp(uint32 mtKeyCode)
@@ -1335,11 +1344,20 @@ bool CDebugInterfaceVice::KeyboardUp(uint32 mtKeyCode)
 			return false;
 	}
 
+	C64KeyMap *keyMap = C64KeyMapGetDefault();
+	if (keyMap == NULL)
+		return false;
+
+	C64KeyCode *key = keyMap->FindKeyCode(mtKeyCode);
+	if (key == NULL)
+		return false;
+
 	CDebugInterfaceViceTaskKeyboardEvent *task =
-		new CDebugInterfaceViceTaskKeyboardEvent(this, DEBUGGER_EVENT_BUTTON_UP, mtKeyCode);
+		new CDebugInterfaceViceTaskKeyboardEvent(this, DEBUGGER_EVENT_BUTTON_UP, mtKeyCode,
+												 key->matrixRow, key->matrixCol, key->shift);
 	AddCpuDebugInterruptTask(task);
 	c64d_vice_input_tasks_flag = 1;
-	return false;
+	return true;
 }
 
 void CDebugInterfaceVice::JoystickDown(int port, uint32 axis)

--- a/src/Emulators/vice/ViceInterface/CDebugInterfaceViceTasks.cpp
+++ b/src/Emulators/vice/ViceInterface/CDebugInterfaceViceTasks.cpp
@@ -10,6 +10,12 @@ extern "C" {
 	void c64d_joystick_key_up(int key, unsigned int joyport);
 	int keyboard_key_pressed(signed long key);
 	int keyboard_key_released(signed long key);
+	int keyboard_key_pressed_matrix(int row, int column, int shift);
+	int keyboard_key_released_matrix(int row, int column, int shift);
+	int keyboard_set_latch_keyarr(int row, int col, int value);
+	void keyboard_set_keyarr_any(int row, int col, int value);
+	void c64d_keyboard_key_down_latch();
+	void c64d_keyboard_key_up_latch();
 }
 
 CDebugInterfaceViceTaskJoystickEvent::CDebugInterfaceViceTaskJoystickEvent(
@@ -83,11 +89,15 @@ void CDebugInterfaceViceTaskJoystickEvent::ExecuteTask()
 }
 
 CDebugInterfaceViceTaskKeyboardEvent::CDebugInterfaceViceTaskKeyboardEvent(
-	CDebugInterfaceVice *debugInterface, u8 buttonState, u32 mtKeyCode)
+	CDebugInterfaceVice *debugInterface, u8 buttonState, u32 mtKeyCode,
+	int matrixRow, int matrixCol, int shift)
 {
 	this->debugInterface = debugInterface;
 	this->buttonState = buttonState;
 	this->mtKeyCode = mtKeyCode;
+	this->matrixRow = matrixRow;
+	this->matrixCol = matrixCol;
+	this->shift = shift;
 }
 
 void CDebugInterfaceViceTaskKeyboardEvent::ExecuteTask()
@@ -100,13 +110,34 @@ void CDebugInterfaceViceTaskKeyboardEvent::ExecuteTask()
 		inputEventsBuffer->PutU8(buttonState);
 	}
 
+	// press/release via the resolved matrix position — same sequence the virtual keyboard
+	// uses (CViewC64KeyMap::SelectKey); the c64d_*_latch calls latch immediately, without
+	// the randomized KEYBOARD_RAND alarm, so measurements stay cycle-deterministic
 	if (buttonState == DEBUGGER_EVENT_BUTTON_DOWN)
 	{
-		keyboard_key_pressed((signed long)mtKeyCode);
+		if (matrixRow < 0)
+		{
+			keyboard_set_keyarr_any(matrixRow, matrixCol, 1);
+		}
+		else
+		{
+			keyboard_key_pressed_matrix(matrixRow, matrixCol, shift);
+			keyboard_set_latch_keyarr(matrixRow, matrixCol, 1);
+			c64d_keyboard_key_down_latch();
+		}
 	}
 	else
 	{
-		keyboard_key_released((signed long)mtKeyCode);
+		if (matrixRow < 0)
+		{
+			keyboard_set_keyarr_any(matrixRow, matrixCol, 0);
+		}
+		else
+		{
+			keyboard_key_released_matrix(matrixRow, matrixCol, shift);
+			keyboard_set_latch_keyarr(matrixRow, matrixCol, 0);
+			c64d_keyboard_key_up_latch();
+		}
 	}
 }
 

--- a/src/Emulators/vice/ViceInterface/CDebugInterfaceViceTasks.h
+++ b/src/Emulators/vice/ViceInterface/CDebugInterfaceViceTasks.h
@@ -21,12 +21,17 @@ public:
 class CDebugInterfaceViceTaskKeyboardEvent : public CDebugInterfaceTask
 {
 public:
-	CDebugInterfaceViceTaskKeyboardEvent(CDebugInterfaceVice *debugInterface, u8 buttonState, u32 mtKeyCode);
+	CDebugInterfaceViceTaskKeyboardEvent(CDebugInterfaceVice *debugInterface, u8 buttonState, u32 mtKeyCode,
+										 int matrixRow, int matrixCol, int shift);
 	virtual void ExecuteTask();
 
 	CDebugInterfaceVice *debugInterface;
 	u8 buttonState;
 	u32 mtKeyCode;
+	// C64 keyboard matrix position resolved from C64KeyMap (matrixRow < 0 = special key, e.g. RESTORE)
+	int matrixRow;
+	int matrixCol;
+	int shift;
 };
 
 class CDebugInterfaceViceTaskReset : public CDebugInterfaceTask

--- a/src/Remote/CDebuggerServerApi.cpp
+++ b/src/Remote/CDebuggerServerApi.cpp
@@ -144,6 +144,37 @@ void CDebuggerServerApi::RegisterEndpoints(CDebuggerServer *server)
 		return server->PrepareResult(HTTP_OK, token, json(), NULL, 0);
 	});
 
+	// Deterministic replay: run exactly N frames then pause. Blocks until finished,
+	// so the reply arriving means the frames have already run (frame = final counter).
+	sprintf(buf, "%s/run/frames", plat);
+	RegisterEndpoint(server, buf, plat, "control", "Run exactly N frames then pause (blocks until finished; count 1..100000)",
+	[this, server](const string token, json params, unsigned char *binaryData, int binaryDataSize) -> vector<char>*
+	{
+		int count = 1;
+		if (params.is_object() && params.contains("count"))
+		{
+			count = params.at("count").get<int>();
+		}
+		if (count < 1 || count > 100000)
+		{
+			return server->PrepareResult(HTTP_NOT_ACCEPTABLE, token, json(), NULL, 0);
+		}
+		if (debugInterface->GetDebugMode() != DEBUGGER_MODE_PAUSED)
+		{
+			json errorJson;
+			errorJson["error"] = "machine must be paused; current+N would race the emulation thread";
+			return server->PrepareResult(HTTP_NOT_ACCEPTABLE, token, errorJson, NULL, 0);
+		}
+		unsigned int frameStart = debuggerApi->GetEmulationFrameNumber();
+		bool completed = debugInterface->RunEmulationForFrames((uint32)count);
+		json result;
+		result["completed"] = completed;
+		result["count"] = count;
+		result["frameStart"] = frameStart;
+		result["frame"] = debuggerApi->GetEmulationFrameNumber();
+		return server->PrepareResult(completed ? HTTP_OK : HTTP_NOT_ACCEPTABLE, token, result, NULL, 0);
+	});
+
 	sprintf(buf, "%s/step/cycle", plat);
 	RegisterEndpoint(server, buf, plat, "cpu", "Step one CPU cycle",
 	[this, server](const string token, json params, unsigned char *binaryData, int binaryDataSize) -> vector<char>*
@@ -319,18 +350,34 @@ void CDebuggerServerApi::RegisterEndpoints(CDebuggerServer *server)
 	RegisterEndpoint(server, buf, plat, "input", "Send key-down event",
 	[this, server](const string token, json params, unsigned char* binaryData, int binaryDataSize) -> vector<char>*
 	{
+		if (!params.is_object() || !params.contains("keyCode") || !params.at("keyCode").is_number_integer())
+		{
+			return server->PrepareResult(HTTP_NOT_ACCEPTABLE, token, json(), NULL, 0);
+		}
 		int mtKeyCode = params.at("keyCode").get<int>();
+		debugInterface->LockIoMutex();
 		bool res = debuggerApi->KeyboardDown(mtKeyCode);
-		return server->PrepareResult(res ? HTTP_OK : HTTP_NOT_ACCEPTABLE, token, json(), NULL, 0);
+		debugInterface->UnlockIoMutex();
+		json result;
+		result["queued"] = res;
+		return server->PrepareResult(res ? HTTP_ACCEPTED : HTTP_NOT_ACCEPTABLE, token, result, NULL, 0);
 	});
 
 	sprintf(buf, "%s/input/key/up", plat);
 	RegisterEndpoint(server, buf, plat, "input", "Send key-up event",
 	[this, server](const string token, json params, unsigned char* binaryData, int binaryDataSize) -> vector<char>*
 	{
+		if (!params.is_object() || !params.contains("keyCode") || !params.at("keyCode").is_number_integer())
+		{
+			return server->PrepareResult(HTTP_NOT_ACCEPTABLE, token, json(), NULL, 0);
+		}
 		int mtKeyCode = params.at("keyCode").get<int>();
+		debugInterface->LockIoMutex();
 		bool res = debuggerApi->KeyboardUp(mtKeyCode);
-		return server->PrepareResult(res ? HTTP_OK : HTTP_NOT_ACCEPTABLE, token, json(), NULL, 0);
+		debugInterface->UnlockIoMutex();
+		json result;
+		result["queued"] = res;
+		return server->PrepareResult(res ? HTTP_ACCEPTED : HTTP_NOT_ACCEPTABLE, token, result, NULL, 0);
 	});
 
 	sprintf(buf, "%s/input/joystick/down", plat);
@@ -941,11 +988,18 @@ void CDebuggerServerApi::RegisterEndpoints(CDebuggerServer *server)
 	RegisterEndpoint(server, buf, plat, "input", "Press a keyboard key (keyCode: MTKEY/SDL keycode; ASCII for printable chars)",
 	[this, server](const string token, json params, unsigned char *binaryData, int binaryDataSize) -> vector<char>*
 	{
+		if (!params.is_object() || !params.contains("keyCode") || !params.at("keyCode").is_number_integer())
+		{
+			return server->PrepareResult(HTTP_NOT_ACCEPTABLE, token, json(), NULL, 0);
+		}
 		uint32_t keyCode = params.at("keyCode").get<uint32_t>();
-		debugInterface->KeyboardDown(keyCode);
+		debugInterface->LockIoMutex();
+		bool queued = debugInterface->KeyboardDown(keyCode);
+		debugInterface->UnlockIoMutex();
 		json result;
 		result["keyCode"] = keyCode;
-		return server->PrepareResult(HTTP_OK, token, result, NULL, 0);
+		result["queued"] = queued;
+		return server->PrepareResult(queued ? HTTP_ACCEPTED : HTTP_NOT_ACCEPTABLE, token, result, NULL, 0);
 	});
 
 	// Keyboard key release
@@ -953,11 +1007,18 @@ void CDebuggerServerApi::RegisterEndpoints(CDebuggerServer *server)
 	RegisterEndpoint(server, buf, plat, "input", "Release a keyboard key (keyCode: MTKEY/SDL keycode; ASCII for printable chars)",
 	[this, server](const string token, json params, unsigned char *binaryData, int binaryDataSize) -> vector<char>*
 	{
+		if (!params.is_object() || !params.contains("keyCode") || !params.at("keyCode").is_number_integer())
+		{
+			return server->PrepareResult(HTTP_NOT_ACCEPTABLE, token, json(), NULL, 0);
+		}
 		uint32_t keyCode = params.at("keyCode").get<uint32_t>();
-		debugInterface->KeyboardUp(keyCode);
+		debugInterface->LockIoMutex();
+		bool queued = debugInterface->KeyboardUp(keyCode);
+		debugInterface->UnlockIoMutex();
 		json result;
 		result["keyCode"] = keyCode;
-		return server->PrepareResult(HTTP_OK, token, result, NULL, 0);
+		result["queued"] = queued;
+		return server->PrepareResult(queued ? HTTP_ACCEPTED : HTTP_NOT_ACCEPTABLE, token, result, NULL, 0);
 	});
 
 	// Emulator start — starts the emulation thread for this platform


### PR DESCRIPTION
## Problem 1: keyboard endpoints never pressed a key

`input/keyDown` / `input/keyUp` replied 200 but no key ever reached the emulated machine ($CB stayed $40), and the newer `input/key/down` / `input/key/up` always replied 406 because `CDebugInterfaceVice::KeyboardDown/Up` unconditionally returned `false` after queueing the task.

Two root causes:
- the queued task called raw `keyboard_key_pressed(mtKeyCode)`, which is a silent no-op when the keyconvmap lookup misses, and even on a hit the latch goes through the randomized `KEYBOARD_RAND()` alarm — bad for cycle-deterministic tooling;
- the queueing path had no way to report failure, so both endpoint families lied.

### Fix
`KeyboardDown/Up` resolve the MTKEY code through `C64KeyMapGetDefault()->FindKeyCode()` at queue time and pass the resolved `(matrixRow, matrixCol, shift)` into the task. `ExecuteTask` presses the matrix position using the same immediate-latch sequence the virtual keyboard view already uses (`CViewC64KeyMap::SelectKey`): `keyboard_key_pressed_matrix` + `keyboard_set_latch_keyarr` + `c64d_keyboard_key_down_latch` (negative rows go through `keyboard_set_keyarr_any`). Unmapped keys and missing/invalid params now return 406; successfully queued events return 202 `{"queued":true}`. Both endpoint families are fixed (the legacy names are also used by the MCP bridge).

## Problem 2: no deterministic N-frame run

There was no API way to run an exact number of frames (external tooling had to drive VICE with `-limitcycles` instead of this debugger).

### Fix
New `<platform>/run/frames {"count":N}` generalizes the existing frame-step mechanism: `RunEmulationForFrames(numFrames)` sets `frameStepTargetFrameNumber = current + N` (`RunEmulationForOneFrame` now delegates with N=1, so GUI/test behavior is unchanged; the completion-wait budget scales with N). The endpoint is synchronous — the reply arrives after the frames have run, carrying `frameStart` and the final `frame` counter — and requires a paused machine (406 otherwise, since computing current+N on a running machine would race the emulation thread).

## Verification (macOS arm64, Xcode 16.4, `build-macos.sh`)

14-point WebSocket gate against the built app, including negative controls:
- `run/frames {count:50}` twice from pause: frame counter advances exactly +50 each time, `frameStart`/`frame` consistent with `cpu/counters/read`; called while running → 406
- `input/keyDown {keyCode:97}` → 202 `{queued:true}`; after `run/frames {count:3}` zeropage $CB reads 10 ('A' matrix code); `keyUp` → $CB back to 64 (no key)
- unmapped `keyCode` → 406; missing param → 406
- `screen/snapshot` (PNG + metadata) unaffected

Commit is on top of current master (af8f1d2).